### PR TITLE
Update sample configs

### DIFF
--- a/doc/config/coraza.cfg
+++ b/doc/config/coraza.cfg
@@ -3,9 +3,10 @@
 spoe-agent coraza-agent
     messages coraza-req coraza-res
     option var-prefix coraza
+    option set-on-error error
     timeout hello      100ms
     timeout idle       2m
-    timeout processing 10ms
+    timeout processing 500ms
     use-backend coraza-spoa
     log global
 

--- a/doc/config/haproxy.cfg
+++ b/doc/config/haproxy.cfg
@@ -3,25 +3,36 @@ global
     log stdout format raw local0
 
 defaults
-    timeout connect 5000ms
-    timeout client 5000ms
-    timeout server 5000ms
     log global
+    option httplog
+    timeout client 1m
+	  timeout server 1m
+	  timeout connect 10s
+	  timeout http-keep-alive 2m
+	  timeout queue 15s
+	  timeout tunnel 4h  # for websocket
 
-frontend coraza.io
+frontend test
     mode http
     bind *:80
     unique-id-format %[uuid()]
     unique-id-header X-Unique-ID
+    log-format "%ci:%cp\ [%t]\ %ft\ %b/%s\ %Th/%Ti/%TR/%Tq/%Tw/%Tc/%Tr/%Tt\ %ST\ %B\ %CC\ %CS\ %tsc\ %ac/%fc/%bc/%sc/%rc\ %sq/%bq\ %hr\ %hs\ %{+Q}r\ %ID\ spoa-error:\ %[var(txn.coraza.error)]\ waf-hit:\ %[var(txn.coraza.fail)]"
+
     filter spoe engine coraza config coraza.cfg
+
+    # Deny for Coraza WAF hits
     http-request deny if { var(txn.coraza.fail) -m int eq 1 }
     http-response deny if { var(txn.coraza.fail) -m int eq 1 }
-    use_backend coraza.io.backend
 
-backend coraza.io.backend
+    # Deny in case of an error, when processing with the Coraza SPOA
+    http-request deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }
+    http-response deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }
+    use_backend test_backend
+
+backend test_backend
     mode http
-    server s1 127.0.0.1:8080
-    server s2 127.0.0.1:9090
+    http-request return status 200 content-type "text/plain" string "Welcome!\n"
 
 backend coraza-spoa
     mode tcp


### PR DESCRIPTION
coraza-spoa

- Increase processing timeout to 500ms
- Set an error variable, in case of timeouts

haproxy

- Use timeouts from official haproxy sample config

-  Add a log format which includes a waf-hit and spoa error variable

-  Deny requests in case of a abnormal/unexpected spoa error/timeout by default. Otherwise Coroza WAF is simply disabled.

-  Provide a sample config, which does not require a backend, but rather simply reply using static content.