### PR TITLE
Include source port, destination ip & port in processConnection

### DIFF
--- a/doc/config/coraza.cfg
+++ b/doc/config/coraza.cfg
@@ -11,7 +11,7 @@ spoe-agent coraza-agent
     log global
 
 spoe-message coraza-req
-    args id=unique-id src-ip=src method=method path=path query=query version=req.ver headers=req.hdrs body=req.body
+    args id=unique-id src-ip=src src-port=src_port dst-ip=dst dst-port=dst_port method=method path=path query=query version=req.ver headers=req.hdrs body=req.body
     event on-frontend-http-request
 
 spoe-message coraza-res


### PR DESCRIPTION
 - Includes the information in the transaction audit log record
 - Populates the engine rule variables

fixes #16