### PR TITLE
Adding github workflow to build & publish Debian packages

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,112 @@
+---
+name: Package Build
+
+on:
+  push:
+    branches:
+      - main
+      - test
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Print Go version and environment
+        id: vars
+        run: |
+          printf "Using go at: $(which go)\n"
+          printf "Go version: $(go version)\n"
+          printf "\n\nGo environment:\n\n"
+          go env
+          printf "\n\nSystem environment:\n\n"
+          env
+
+          SEMVER_RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z\.-]*\)'
+          echo TAG_MAJOR=`echo ${TAG#v}   | sed -e "s#$SEMVER_RE#\1#"` >> $GITHUB_ENV
+          echo TAG_MINOR=`echo ${TAG#v}   | sed -e "s#$SEMVER_RE#\2#"` >> $GITHUB_ENV
+          echo TAG_PATCH=`echo ${TAG#v}   | sed -e "s#$SEMVER_RE#\3#"` >> $GITHUB_ENV
+          echo TAG_SPECIAL=`echo ${TAG#v} | sed -e "s#$SEMVER_RE#\4#"` >> $GITHUB_ENV
+
+          if [[ $GITHUB_REF_TYPE == "branch" ]]; then
+            echo "PACKAGE_VERSION=$(date +%Y%m%d%H%M)-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+          else
+            echo "PACKAGE_VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+          fi
+
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt -y install make pkg-config rubygems && sudo gem install fpm
+
+          # Download corazawaf/coraza/coraza.conf for distribution
+          curl https://raw.githubusercontent.com/corazawaf/coraza/v2/master/coraza.conf-recommended > coraza.conf
+
+      - name: Build binary
+        run: VERSION=${PACKAGE_VERSION} ARCH=${{ matrix.arch }} make
+
+      - name: Build package
+        run: |
+         fpm -s dir -t deb -a ${{ matrix.arch }} -n coraza-spoa -v $PACKAGE_VERSION  \
+           --description "Coraza HAProxy SPOA" \
+           --url "https://www.coraza.io" \
+           --maintainer "OWASP Coraza Team" \
+           --license Apache-2.0 \
+           --vendor OWASP \
+           --after-install ./contrib/coraza-spoa.postinst \
+           --deb-systemd ./contrib/coraza-spoa.service \
+           --deb-systemd-enable \
+           --config-files /etc/coraza-spoa/config.yaml \
+           ./coraza-spoa_${{matrix.arch}}=/usr/bin/coraza-spoa \
+           ./doc/config/=/usr/share/doc/coraza-spoa/haproxy-config \
+           ./LICENSE=/usr/share/doc/coraza-spoa/ \
+           ./config.yaml.default=/etc/coraza-spoa/config.yaml \
+           ./coraza.conf=/etc/coraza-spoa/coraza.conf
+
+      ## Publish to the "testing" repo
+      - name: Cloudsmith Push: debian/coraza-spoa-snapshots
+        if: ${{ github.ref_type == 'branch' }}
+        uses: cloudsmith-io/action@master
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: "push"
+          format: "deb"
+          owner: "coraza"               # Your Cloudsmith account name or org name (namespace)
+          repo: "coraza-spoa-snapshots" # Your Cloudsmith Repository name (slug)
+          distro: "any-distro"          # Your Distribution  (i.e Debian, Ubuntu)
+          release: "any-version"        # Your Distribution Release (i.e xenial, buster)
+          file: "coraza-spoa_${PACKAGE_VERSION}_${{matrix.arch}}.deb" # debian package filename
+
+      ## Publish tags to the "main" repo
+      - name: Cloudsmith Push: debian/coraza-spoa
+        if: ${{ github.ref_type == 'tag' }}
+        uses: cloudsmith-io/action@master
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: "push"
+          format: "deb"
+          owner: "coraza"            # Your Cloudsmith account name or org name (namespace)
+          repo: "coraza-spoa"        # Your Cloudsmith Repository name (slug)
+          distro: "any-distro"       # Your Distribution  (i.e Debian, Ubuntu)
+          release: "any-version"     # Your Distribution Release (i.e xenial, buster)
+          file: "coraza-spoa_${PACKAGE_VERSION}_${{matrix.arch}}.deb"  # debian package filename
+
+      #- name: cloudsmith/rpm
+      #  id: cloudsmith-rpm
+      #  uses: cloudsmith-io/action@master
+      #  with:
+      #    api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+      #    command: "push"
+      #    format: "rpm"
+      #    owner: "ono"               # Your Cloudsmith account name or org name (namespace)
+      #    repo: "coraza-spoa"        # Your Cloudsmith Repository name (slug)
+      #    distro: "any-distro"       # Your Distribution  (i.e el, fedora)
+      #    release: "any-distro"      # Your Distribution Release (i.e 7, 32)
+      #    republish: "true"          # needed ONLY if version is not changing
+      #    file: "YOUR-FILENAME.rpm"  #rpm package filename

--- a/Makefile
+++ b/Makefile
@@ -12,28 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.DEFAULT_GOAL := build
+BINARY = coraza-spoa
 
-HOST_ARCH = $(shell which go >/dev/null 2>&1 && go env GOARCH)
-ARCH ?= $(HOST_ARCH)
+VERSION ?= "dev"
+REVISION ?= $(shell git rev-parse HEAD)
+
+ARCH ?= $(shell which go >/dev/null 2>&1 && go env GOARCH)
+
 ifeq ($(ARCH),)
 	$(error mandatory variable ARCH is empty, either set it when calling the command or make sure 'go env GOARCH' works)
 endif
 
-HOST_OS = $(shell which go >/dev/null 2>&1 && go env GOOS)
-OS ?= $(HOST_OS)
+OS ?= $(shell which go >/dev/null 2>&1 && go env GOOS)
+
 ifeq ($(OS),)
 	$(error mandatory variable OS is empty, either set it when calling the cammand or make sure 'go env GOOS' works)
 endif
 
-EXECUTABLE_FILE = coraza-spoa
+#LDFLAGS = -ldflags "-X main.Version=${VERSION} -X main.Revision=${REVISION}"
 
-.PHONY: build
+
+default: build
+
 build:
-	@GOARCH=$(ARCH) go build -o $(EXECUTABLE_FILE) cmd/main.go
+	GOARCH=$(ARCH) GOOS=$(OS) go build -v ${LDFLAGS} -o $(BINARY)_$(ARCH) cmd/main.go
 
-.PHONY: clean
-clean: $(BUILD_FILES)
-	@rm -rf $(EXECUTABLE_FILE)
-
-
+clean:
+	rm -f $(BINARY)_amd64 $(BINARY)_arm64 $(BINARY)_386


### PR DESCRIPTION
Introduce Github Actions for building Binaries & Debian Package

### Build Platform
Github Actions
Github Ubuntu 22.04
Go 1.18.2

Builds are performed using matrix jobs, each job creates a package for a supported platform. Currently configured are: amd64, arm64

#### Release of a test package to perform testing by a user

A commit is merged to the main branch, a test version automatically gets built. The package is versioned with the current date, hour, minute and git hash of the commit. Example:

 `coraza-spoa-202206210000-81d12f7_amd64.deb`

The package is then pushed to the snapshot repository and allows a user to perform testing. Steps:
 - Change the repo in apt/sources.list
 - Install a snapshot version: `apt install -t coraza-spoa=202206210000-81d12f7`

#### Release of a versioned package

A git tag is created. The tag follows semver semantics (eg. v0.0.1). A release package automatically gets built. The package is versioned with the version number found in the git tag. Example:

 `coraza-spoa-0.0.1_amd64.deb`

The package is pushed to the release repository `coraza/coraza-spoa` and users who use the repository automatically receive updates.



