### PR TITLE
change eviction algorithm and apply ttl (Fix #15)

### DIFF
--- a/internal/spoa.go
+++ b/internal/spoa.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/bluele/gcache"
 	"github.com/corazawaf/coraza-spoa/config"
@@ -125,6 +126,6 @@ func New(cfg *config.SPOA) (*SPOA, error) {
 			if err := tx.Clean(); err != nil {
 				logger.Error("Failed to clean cache", zap.Error(err))
 			}
-		}).ARC().Build()
+		}).LFU().Expiration(time.Duration(cfg.TransactionTTL) * time.Second).Build()
 	return s, nil
 }


### PR DESCRIPTION
- ARC algorithm requires a TTL
- Evict function will only work with TTL
- I replaced ARC (LFU+LRU) with LFU, LFU is better for our use case as it will evict old objects
- I added the cache from the settings