### PR TITLE
feat: Introduce "default_application" config param

### DIFF
--- a/cmd/coraza-spoa/main.go
+++ b/cmd/coraza-spoa/main.go
@@ -30,7 +30,7 @@ func main() {
 	if err := config.InitConfig(*cfg); err != nil {
 		panic(err)
 	}
-	spoa, err := internal.New(config.Global.Applications)
+	spoa, err := internal.New(config.Global)
 	if err != nil {
 		panic(err)
 	}

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -2,6 +2,9 @@
 # The SPOA server bind address
 bind: 0.0.0.0:9000
 
+# Process with this application if request's provided app is not found
+default_application: sample_app
+
 applications:
   sample_app:
     # Get the coraza.conf from https://github.com/corazawaf/coraza

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -2,7 +2,9 @@
 # The SPOA server bind address
 bind: 0.0.0.0:9000
 
-# Process with this application if request's provided app is not found
+# Process request with specified application if provided app is not found.
+# You can comment out "default_application" configuration parameter
+# if you don't need this functionality.
 default_application: sample_app
 
 applications:

--- a/config/config.go
+++ b/config/config.go
@@ -26,8 +26,9 @@ var Global *Config
 
 // Config is used to configure coraza-server.
 type Config struct {
-	Bind         string                  `yaml:"bind"`
-	Applications map[string]*Application `yaml:"applications"`
+	Bind               string                  `yaml:"bind"`
+	DefaultApplication string                  `yaml:"default_application"`
+	Applications       map[string]*Application `yaml:"applications"`
 }
 
 // Application is used to manage the haproxy configuration and waf rules.

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -20,7 +20,7 @@ frontend stats
     stats refresh 10s
     stats show-modules
 
-frontend sample_app
+frontend test_frontend
     mode http
     bind *:80
     bind *:443 ssl crt /usr/local/etc/haproxy/example.com.pem alpn h2,http/1.1

--- a/internal/request.go
+++ b/internal/request.go
@@ -54,10 +54,10 @@ func (s *SPOA) processRequest(msg spoe.Message) ([]spoe.Action, error) {
 					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.defaultApplication)
 					app, ok = s.applications[s.defaultApplication]
 					if !ok {
-						return nil, fmt.Errorf("default application %q not found", s.defaultApplication)
+						return nil, fmt.Errorf("default application not found: %s", s.defaultApplication)
 					}
 				} else {
-					return nil, fmt.Errorf("application %q not found", arg.Value.(string))
+					return nil, fmt.Errorf("application not found: %v", arg.Value)
 				}
 			}
 		case "id":

--- a/internal/request.go
+++ b/internal/request.go
@@ -50,11 +50,11 @@ func (s *SPOA) processRequest(msg spoe.Message) ([]spoe.Action, error) {
 			var ok bool
 			app, ok = s.applications[arg.Value.(string)]
 			if !ok {
-				if len(s.default_application) > 0 {
-					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.default_application)
-					app, ok = s.applications[s.default_application]
+				if len(s.defaultApplication) > 0 {
+					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.defaultApplication)
+					app, ok = s.applications[s.defaultApplication]
 					if !ok {
-						return nil, fmt.Errorf("default application %q not found", s.default_application)
+						return nil, fmt.Errorf("default application %q not found", s.defaultApplication)
 					}
 				} else {
 					return nil, fmt.Errorf("application %q not found", arg.Value.(string))

--- a/internal/request.go
+++ b/internal/request.go
@@ -50,7 +50,15 @@ func (s *SPOA) processRequest(msg spoe.Message) ([]spoe.Action, error) {
 			var ok bool
 			app, ok = s.applications[arg.Value.(string)]
 			if !ok {
-				return nil, fmt.Errorf("application %q not found", arg.Value.(string))
+				if len(s.default_application) > 0 {
+					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.default_application)
+					app, ok = s.applications[s.default_application]
+					if !ok {
+						return nil, fmt.Errorf("default application %q not found", s.default_application)
+					}
+				} else {
+					return nil, fmt.Errorf("application %q not found", arg.Value.(string))
+				}
 			}
 		case "id":
 			tx = app.waf.NewTransaction(context.Background())
@@ -135,7 +143,7 @@ func (s *SPOA) processRequest(msg spoe.Message) ([]spoe.Action, error) {
 		case "body":
 			body, ok := arg.Value.([]byte)
 			if !ok {
-				return nil, fmt.Errorf("invalid argument for http reqeust body, []byte expected, got %v", arg.Value)
+				return nil, fmt.Errorf("invalid argument for http request body, []byte expected, got %v", arg.Value)
 			}
 
 			_, err := tx.RequestBodyBuffer.Write(body)

--- a/internal/request.go
+++ b/internal/request.go
@@ -51,11 +51,11 @@ func (s *SPOA) processRequest(msg spoe.Message) ([]spoe.Action, error) {
 			app, ok = s.applications[arg.Value.(string)]
 			if !ok {
 				if len(s.defaultApplication) > 0 {
-					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.defaultApplication)
 					app, ok = s.applications[s.defaultApplication]
 					if !ok {
 						return nil, fmt.Errorf("default application not found: %s", s.defaultApplication)
 					}
+					app.logger.Debug("application not found, using default", zap.Any("application", arg.Value), zap.String("default", s.defaultApplication))
 				} else {
 					return nil, fmt.Errorf("application not found: %v", arg.Value)
 				}

--- a/internal/response.go
+++ b/internal/response.go
@@ -46,11 +46,11 @@ func (s *SPOA) processResponse(msg spoe.Message) ([]spoe.Action, error) {
 			app, ok = s.applications[arg.Value.(string)]
 			if !ok {
 				if len(s.defaultApplication) > 0 {
-					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.defaultApplication)
 					app, ok = s.applications[s.defaultApplication]
 					if !ok {
 						return nil, fmt.Errorf("default application not found: %s", s.defaultApplication)
 					}
+					app.logger.Debug("application not found, using default", zap.Any("application", arg.Value), zap.String("default", s.defaultApplication))
 				} else {
 					return nil, fmt.Errorf("application not found: %v", arg.Value)
 				}

--- a/internal/response.go
+++ b/internal/response.go
@@ -45,11 +45,11 @@ func (s *SPOA) processResponse(msg spoe.Message) ([]spoe.Action, error) {
 			var ok bool
 			app, ok = s.applications[arg.Value.(string)]
 			if !ok {
-				if len(s.default_application) > 0 {
-					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.default_application)
-					app, ok = s.applications[s.default_application]
+				if len(s.defaultApplication) > 0 {
+					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.defaultApplication)
+					app, ok = s.applications[s.defaultApplication]
 					if !ok {
-						return nil, fmt.Errorf("default application %q not found", s.default_application)
+						return nil, fmt.Errorf("default application %q not found", s.defaultApplication)
 					}
 				} else {
 					return nil, fmt.Errorf("application %q not found", arg.Value.(string))

--- a/internal/response.go
+++ b/internal/response.go
@@ -45,7 +45,15 @@ func (s *SPOA) processResponse(msg spoe.Message) ([]spoe.Action, error) {
 			var ok bool
 			app, ok = s.applications[arg.Value.(string)]
 			if !ok {
-				return nil, fmt.Errorf("application %q not found", arg.Value.(string))
+				if len(s.default_application) > 0 {
+					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.default_application)
+					app, ok = s.applications[s.default_application]
+					if !ok {
+						return nil, fmt.Errorf("default application %q not found", s.default_application)
+					}
+				} else {
+					return nil, fmt.Errorf("application %q not found", arg.Value.(string))
+				}
 			}
 		case "id":
 			id, ok := arg.Value.(string)

--- a/internal/response.go
+++ b/internal/response.go
@@ -49,10 +49,10 @@ func (s *SPOA) processResponse(msg spoe.Message) ([]spoe.Action, error) {
 					fmt.Printf("application %q not found, using default application %q\n", arg.Value.(string), s.defaultApplication)
 					app, ok = s.applications[s.defaultApplication]
 					if !ok {
-						return nil, fmt.Errorf("default application %q not found", s.defaultApplication)
+						return nil, fmt.Errorf("default application not found: %s", s.defaultApplication)
 					}
 				} else {
-					return nil, fmt.Errorf("application %q not found", arg.Value.(string))
+					return nil, fmt.Errorf("application not found: %v", arg.Value)
 				}
 			}
 		case "id":

--- a/internal/spoa.go
+++ b/internal/spoa.go
@@ -48,7 +48,8 @@ type application struct {
 
 // SPOA store the relevant data for starting SPOA.
 type SPOA struct {
-	applications map[string]*application
+	applications        map[string]*application
+	default_application string
 }
 
 // Start starts the SPOA to detect the security risks.
@@ -113,9 +114,9 @@ func (s *SPOA) cleanApplications() {
 }
 
 // New creates a new SPOA instance.
-func New(conf map[string]*config.Application) (*SPOA, error) {
+func New(conf *config.Config) (*SPOA, error) {
 	apps := make(map[string]*application)
-	for name, cfg := range conf {
+	for name, cfg := range conf.Applications {
 		pe := zap.NewProductionEncoderConfig()
 
 		fileEncoder := zapcore.NewJSONEncoder(pe)
@@ -177,6 +178,7 @@ func New(conf map[string]*config.Application) (*SPOA, error) {
 		apps[name] = app
 	}
 	return &SPOA{
-		applications: apps,
+		applications:        apps,
+		default_application: conf.DefaultApplication,
 	}, nil
 }

--- a/internal/spoa.go
+++ b/internal/spoa.go
@@ -48,8 +48,8 @@ type application struct {
 
 // SPOA store the relevant data for starting SPOA.
 type SPOA struct {
-	applications        map[string]*application
-	default_application string
+	applications       map[string]*application
+	defaultApplication string
 }
 
 // Start starts the SPOA to detect the security risks.
@@ -178,7 +178,7 @@ func New(conf *config.Config) (*SPOA, error) {
 		apps[name] = app
 	}
 	return &SPOA{
-		applications:        apps,
-		default_application: conf.DefaultApplication,
+		applications:       apps,
+		defaultApplication: conf.DefaultApplication,
 	}, nil
 }


### PR DESCRIPTION
I use `hdr(host)` as `app` in `spoe-message` for more dynamic configuration. For every hostname I define an application in `coraza-spoe`, but I noticed, if i open my web by typing an IP address, the request is also processed by SPOA and it throws an error that "an application `<MY_IP_ADDRESS>` is not found". That's why I thought that it would be a great idea to define default application for requests that has no application defined. If somebody does not want a default application behaviour, then config parameter `default_application` can be commented out.