### PR TITLE
chore: upgrades coraza docker

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -41,17 +41,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
 
       - name: Login to GHCR
         uses: docker/login-action@v2
@@ -60,12 +56,58 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Docker metadata - Main
+        id: meta1
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=snapshot,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=snapshot,enable=${{ github.ref == format('refs/heads/{0}', 'upgrades_coraza_docker') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Image - Main
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta1.outputs.tags }}
+          labels: ${{ steps.meta1.outputs.labels }}
+
+
+      - name: Docker metadata - CRS4
+        id: meta4
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/sts/coraza-spoa
+          flavor: |
+            suffix=-crs4,onlatest=true
+          tags: |
+            type=raw,value=snapshot,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=snapshot,enable=${{ github.ref == format('refs/heads/{0}', 'upgrades_coraza_docker') }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Image - CRS4
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          target: coreruleset
+          build-args: |
+            CORERULESET_VERSION=v4.0.0-rc1
+          tags: ${{ steps.meta4.outputs.tags }}
+          labels: ${{ steps.meta4.outputs.labels }}

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -57,7 +57,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker metadata - Main
-        id: meta1
+        id: meta-main
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
@@ -77,12 +77,12 @@ jobs:
           platforms: linux/amd64
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta1.outputs.tags }}
-          labels: ${{ steps.meta1.outputs.labels }}
+          tags: ${{ steps.meta-main.outputs.tags }}
+          labels: ${{ steps.meta-main.outputs.labels }}
 
 
       - name: Docker metadata - CRS4
-        id: meta4
+        id: meta-crs4
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
@@ -107,5 +107,5 @@ jobs:
           target: coreruleset
           build-args: |
             CORERULESET_VERSION=v4.0.0-rc1
-          tags: ${{ steps.meta4.outputs.tags }}
-          labels: ${{ steps.meta4.outputs.labels }}
+          tags: ${{ steps.meta-crs4.outputs.tags }}
+          labels: ${{ steps.meta-crs4.outputs.labels }}

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -85,7 +85,7 @@ jobs:
         id: meta4
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/sts/coraza-spoa
+          images: ghcr.io/${{ github.repository }}
           flavor: |
             suffix=-crs4,onlatest=true
           tags: |

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -63,7 +63,6 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=snapshot,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=snapshot,enable=${{ github.ref == format('refs/heads/{0}', 'upgrades_coraza_docker') }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
@@ -91,7 +90,6 @@ jobs:
             suffix=-crs4,onlatest=true
           tags: |
             type=raw,value=snapshot,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=snapshot,enable=${{ github.ref == format('refs/heads/{0}', 'upgrades_coraza_docker') }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,81 @@
 # Copyright 2023 The OWASP Coraza contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.19.1-alpine3.16 AS build
+FROM --platform=$BUILDPLATFORM golang:1.19-alpine3.17 AS builder
 
-# Specify Coreruleset version to download
-ARG CORERULESET_VERSION=v4.0.0-rc1
-ARG CORERULESET_MD5=9140236dc7e941c274e414385824c996
+WORKDIR /build
+COPY . /build
 
-# Change working directory
-WORKDIR /app
-
-RUN \
-    apk add --no-cache \
-    # Install make to build coraza-spoa binary from makefile
-    make \
-    # Download and set up Coreruleset
-    && wget -qO/tmp/coreruleset.tar.gz https://github.com/coreruleset/coreruleset/archive/${CORERULESET_VERSION}.tar.gz \
-    && echo "$CORERULESET_MD5  /tmp/coreruleset.tar.gz" | md5sum -c \
-    && mkdir -p /tmp/coraza-coreruleset \
-    && mkdir -p /etc/coraza-spoa/rules \
-    && tar xzf /tmp/coreruleset.tar.gz --strip-components=1 -C /tmp/coraza-coreruleset \
-    && mv /tmp/coraza-coreruleset/crs-setup.conf.example /etc/coraza-spoa/crs-setup.conf \
-    && mv /tmp/coraza-coreruleset/rules /etc/coraza-spoa \
-    && mv /tmp/coraza-coreruleset/plugins /etc/coraza-spoa \
-    && rm -rf /tmp/*
-
-# Cache Go dependencies
-COPY go.mod go.sum ./
+# Download dependencies for all platforms once
 RUN go mod download
 
-# Copy project files into build image
-COPY . .
+ARG TARGETOS
+ARG TARGETARCH
 
-# Build coraza-spoa binary
-RUN make
+RUN apk add --no-cache make ca-certificates \
+    && update-ca-certificates
 
-RUN \
-    # Move coraza-spoa config file to config dir
-    mv /app/docker/coraza-spoa/coraza.conf /etc/coraza-spoa/coraza.conf \
-    # Rename coraza-spoa default config file
-    && mv /app/config.yaml.default /app/config.yaml \
-    # Rename coraza-spoa binary
-    && mv /app/coraza-spoa_amd64 /app/coraza-spoa \
-    # Make coraza-spoa binary executable
-    && chmod +x /app/coraza-spoa
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    OS=${TARGETOS} ARCH=${TARGETARCH} make
 
+# ---
+FROM alpine:3.17 AS main
 
+ARG TARGETARCH
 
-FROM alpine:3.16
-# Make directory for coraza-spoa audit and error logs
-RUN mkdir -p /var/log/coraza-spoa
-# Copy coraza-spoa binary and default config file from build image
-COPY --from=build /app/config.yaml /app/coraza-spoa /
-# Copy Coreruleset files from build image
-COPY --from=build /etc/coraza-spoa /etc/coraza-spoa
+LABEL org.opencontainers.image.authors="OWASP Coraza Maintainers" \
+      org.opencontainers.image.description="OWASP Coraza WAF (Haproxy SPOA)" \
+      org.opencontainers.image.documentation="https://coraza.io/connectors/coraza-spoa/" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/corazawaf/coraza-spoa" \
+      org.opencontainers.image.title="coraza-spoa"
 
-# Container run command
-CMD ["/coraza-spoa", "-config", "/config.yaml"]
+RUN apk add --no-cache tini socat ca-certificates \
+    && update-ca-certificates
+
+# Add unprivileged user & group for the coraza-spoa
+RUN addgroup --system coraza-spoa \
+    && adduser --system --ingroup coraza-spoa --no-create-home --home /nonexistent --disabled-password coraza-spoa
+
+RUN mkdir -p /etc/coraza-spoa /var/log/coraza-spoa \
+    && chown coraza-spoa:coraza-spoa /var/log/coraza-spoa
+
+COPY --from=builder /build/coraza-spoa_${TARGETARCH} /usr/bin/coraza-spoa
+COPY --from=builder /build/config.yaml.default /etc/coraza-spoa/config.yaml
+COPY --from=builder /build/docker/coraza-spoa/coraza.conf /etc/coraza-spoa/coraza.conf
+COPY --from=builder /build/docker/coraza-spoa/docker-entrypoint.sh /docker-entrypoint.sh
+
+EXPOSE 9000
+USER coraza-spoa
+
+HEALTHCHECK --interval=10s --timeout=2s --retries=2 CMD "/usr/bin/socat /dev/null TCP:0.0.0.0:9000"
+
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
+
+CMD ["/usr/bin/coraza-spoa", "--config", "/etc/coraza-spoa/config.yaml"]
+
+# ---
+FROM main AS coreruleset
+
+ARG CORERULESET_VERSION=v4.0.0-rc1
+ARG CORERULESET_SHA256SUM=a8f0d1cac941bf2158988b92a91519f093a8bce64a260e46fa352d608c7de3e6
+
+# Switch to root for crs installation
+USER root
+
+# Download the core rule set
+RUN set -xe \
+    && wget -O /tmp/crs.tgz https://github.com/coreruleset/coreruleset/archive/refs/tags/${CORERULESET_VERSION}.tar.gz
+
+RUN echo "$CORERULESET_SHA256SUM  /tmp/crs.tgz" | sha256sum -c
+
+RUN set -xe \
+    && mkdir crs \
+    && tar --strip-components 1 -C crs -xf /tmp/crs.tgz \
+    && mv crs/crs-setup.conf.example /etc/coraza-spoa/crs-setup.conf \
+    && mv crs/rules /etc/coraza-spoa \
+    && if [[ -d crs/plugins ]] ; then mv crs/plugins /etc/coraza-spoa ; fi \
+    && rm -rf crs /tmp/crs.tgz
+
+USER coraza-spoa

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM alpine:3.17 AS main
 
 ARG TARGETARCH
 
-LABEL org.opencontainers.image.authors="OWASP Coraza Maintainers" \
+LABEL org.opencontainers.image.authors="The OWASP Coraza contributors" \
       org.opencontainers.image.description="OWASP Coraza WAF (Haproxy SPOA)" \
       org.opencontainers.image.documentation="https://coraza.io/connectors/coraza-spoa/" \
       org.opencontainers.image.licenses="Apache-2.0" \

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -3,9 +3,11 @@ services:
   httpbin:
     image: mccutchen/go-httpbin:v2.5.0
     ports:
-      - 8080
+      - 8080:8080
   coraza:
-    build: .
+    build:
+      context: .
+      target: coreruleset
     volumes:
       - ./docker/e2e/e2e-rules.conf:/etc/coraza-spoa/rules/000-e2e-rules.conf
   haproxy:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,10 +4,12 @@ services:
     restart: unless-stopped
     image: mccutchen/go-httpbin:v2.5.0
     ports:
-      - 8080
+      - 8080:8080
   coraza:
     restart: unless-stopped
-    build: .
+    build:
+      context: .
+      target: coreruleset
   haproxy:
     restart: unless-stopped
     image: haproxy:2.7-alpine

--- a/docker/coraza-spoa/coraza.conf
+++ b/docker/coraza-spoa/coraza.conf
@@ -223,7 +223,7 @@ SecDataDir /tmp/
 # trigger a server error (determined by a 5xx or 4xx, excluding 404,
 # level response status codes).
 #
-SecAuditEngine On
+SecAuditEngine Off
 SecAuditLogRelevantStatus "^(?:(5|4)(0|1)[0-9])$"
 
 # Log everything we know about a transaction.
@@ -232,9 +232,9 @@ SecAuditLogParts ABIJDEFHZ
 # Use a single file for logging. This is much easier to look at, but
 # assumes that you will use the audit log only occasionally.
 #
-SecAuditLog /var/log/coraza-spoa/audit.log
-SecAuditLogFormat json
-SecAuditLogType Serial
+#SecAuditLog /var/log/coraza-spoa/audit.log
+#SecAuditLogFormat json
+#SecAuditLogType Serial
 
 
 # -- Miscellaneous -----------------------------------------------------------

--- a/docker/coraza-spoa/docker-entrypoint.sh
+++ b/docker/coraza-spoa/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if [ $# -gt 0 ] && [ "$1" = "${1#-}" ]; then
+    # First char isn't `-`, probably a `docker run -ti <cmd>`
+    # Just exec and exit
+    exec "$@"
+    exit
+fi
+
+exec coraza-spoa --config /etc/coraza-spoa/config.yaml

--- a/docker/coraza-spoa/docker-entrypoint.sh
+++ b/docker/coraza-spoa/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+# Allow users to run arbitrary commands within the container
+
 if [ $# -gt 0 ] && [ "$1" = "${1#-}" ]; then
     # First char isn't `-`, probably a `docker run -ti <cmd>`
     # Just exec and exit

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect
-	github.com/magefile/mage v1.14.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/magefile/mage v1.14.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect


### PR DESCRIPTION
- Run coraza-spoa as unprivileged user within the container
- Device images in a main image without CRS and a coreruleset target to include CRS
- Add multiarch images for multiple platforms
- Use docker-entrypoint.sh
- Use tini