### PR TITLE
Return 'hit' fail value through processInterruption

### DIFF
--- a/internal/spoa.go
+++ b/internal/spoa.go
@@ -96,6 +96,11 @@ func (s *SPOA) processInterruption(it *types.Interruption, code int) []spoe.Acti
 			Scope: spoe.VarScopeTransaction,
 			Value: it.RuleID,
 		},
+		spoe.ActionSetVar{
+			Name:  "fail",
+			Scope: spoe.VarScopeTransaction,
+			Value: code,
+		},
 	}
 }
 


### PR DESCRIPTION
Return the missing fail variable in case of a hit. It's more consistent and makes the haproxy config examples actually work. E.g. this bit:

```
http-request deny if { var(txn.coraza.fail) -m int eq 1 }
http-response deny if { var(txn.coraza.fail) -m int eq 1 }
```