### PR TITLE
Update documenation to avoid errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Coraza SPOA is a system daemon which runs the Coraza Web Application Firewall (WAF) as a backing service for HAProxy.  HAProxy includes a Stream Processing Offload Engine (SPOE) to offload request processing to a Stream Processing Offload Agent (SPOA). The SPOA applies filtering to the request and response using [OWASP Coraza](https://github.com/corazawaf/coraza) and provides the final verdict.
+Coraza SPOA is a system daemon which runs the Coraza Web Application Firewall (WAF) as a backing service for HAProxy.  HAProxy includes a [Stream Processing Offload Engine] (https://www.haproxy.com/blog/extending-haproxy-with-the-stream-processing-offload-engine) [SPOE](https://raw.githubusercontent.com/haproxy/haproxy/master/doc/SPOE.txt) to offload request processing to a Stream Processing Offload Agent (SPOA). The SPOA analyzes the request and response using [OWASP Coraza](https://github.com/corazawaf/coraza) and provides the final verdict back to HAProxy.
 
 ## Compilation
 
@@ -19,7 +19,7 @@ When you need to re-compile the source code, you can use the command `make clean
 
 ## Coraza SPOA
 
-The example configuration file is `config.yaml.default`, you can copy it and modify the related configuration information. You can start the service by running the command:
+The example configuration file is [config.yaml.default](https://github.com/corazawaf/coraza-spoa/blob/main/config.yaml.default), you can copy it and modify the related configuration information. You can start the service by running the command:
 
 ```
 coraza-spoa -config /etc/coraza-spoa/coraza.yaml
@@ -28,7 +28,7 @@ coraza-spoa -config /etc/coraza-spoa/coraza.yaml
 
 ## Configure a SPOE to use the service
 
-Here is the configuration template to use for your SPOE with OWASP Coraza module, you can find it in the [doc/config/coraza.cfg](https://github.com/corazawaf/coraza-spoa/blob/main/doc/config/coraza.cfg):
+The example SPOE configuration file is [coraza.cfg](https://github.com/corazawaf/coraza-spoa/blob/main/doc/config/coraza.cfg), you can copy it and modify the related configuration information. Default directory to place the config is `/etc/haproxy/coraza.cfg`.
 
 ```ini
 # /etc/haproxy/coraza.cfg
@@ -58,7 +58,10 @@ spoe-message coraza-res
 
 Instead of hard coded application name `str(sample_app)` you can use some HAProxy's variable. For example, frontend name `fe_name` or some custom variable.
 
-The engine is in the scope "coraza". So to enable it, you must set the following line in a frontend/listener section:
+The engine is in the scope `coraza`. So to enable it, you must set [the following line](https://github.com/corazawaf/coraza-spoa/blob/88b4e54ab3ddcb58d946ed1d6389eff73745575b/doc/config/haproxy.cfg#L21) in a `frontend` / `listener` section HAProxy config:
+```haproxy
+    filter spoe engine coraza config /etc/haproxy/coraza.cfg
+    ...
 
 ```haproxy
 # /etc/haproxy/haproxy.cfg
@@ -89,7 +92,10 @@ frontend web
     use_backend web_backend
 ```
 
-Because, in the SPOE configuration file (coraza.cfg), we declare to use the backend "coraza-spoa" to communicate with the service, so we need to define it in the HAProxy file. For example:
+Because, in the SPOE configuration file (coraza.cfg), we declare to use the backend [coraza-spoa](https://github.com/corazawaf/coraza-spoa/blob/88b4e54ab3ddcb58d946ed1d6389eff73745575b/doc/config/coraza.cfg#L14) to communicate with the service, so we need also to define it in the [HAProxy file](https://github.com/corazawaf/coraza-spoa/blob/dd5eb86d1e9abbdd5fe568249f36a6d85257eba7/doc/config/haproxy.cfg#L37):
+```haproxy
+backend coraza-spoa
+    ...
 
 ```haproxy
 # /etc/haproxy/haproxy.cfg

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -18,7 +18,8 @@ applications:
       Include /etc/coraza-spoa/rules/*.conf
 
     # HAProxy configured to send requests only, that means no cache required
-    no_response_check: false
+    # NOTE: there are still some memory & caching issues, so use this with care
+    no_response_check: true
 
     # The transaction cache lifetime in milliseconds (60000ms = 60s)
     transaction_ttl_ms: 60000

--- a/doc/config/coraza.cfg
+++ b/doc/config/coraza.cfg
@@ -1,9 +1,10 @@
 # https://github.com/haproxy/haproxy/blob/master/doc/SPOE.txt
+# /etc/haproxy/coraza.cfg
 [coraza]
 spoe-agent coraza-agent
-    # Filter http requests (the response is not evaluated)
+    # Process HTTP requests only (the responses are not evaluated)
     messages    coraza-req
-    # Comment the previous line and add coraza-res, to also apply response filters.
+    # Comment the previous line and add coraza-res, to process responses also.
     # NOTE: there are still some memory & caching issues, so use this with care
     #messages   coraza-req     coraza-res
     option      var-prefix      coraza

--- a/doc/config/coraza.cfg
+++ b/doc/config/coraza.cfg
@@ -1,10 +1,14 @@
 # https://github.com/haproxy/haproxy/blob/master/doc/SPOE.txt
 [coraza]
 spoe-agent coraza-agent
-    messages    coraza-req      coraza-res
+    # Filter http requests (the response is not evaluated)
+    messages    coraza-req
+    # Comment the previous line and add coraza-res, to also apply response filters.
+    # NOTE: there are still some memory & caching issues, so use this with care
+    #messages   coraza-req     coraza-res
     option      var-prefix      coraza
     option      set-on-error    error
-    timeout     hello           100ms
+    timeout     hello           2s
     timeout     idle            2m
     timeout     processing      500ms
     use-backend coraza-spoa

--- a/doc/config/haproxy.cfg
+++ b/doc/config/haproxy.cfg
@@ -45,3 +45,4 @@ backend coraza-spoa
     balance roundrobin
     timeout connect 5s # greater than hello timeout
     timeout server 3m  # greater than idle timeout
+    server s1 127.0.0.1:9000

--- a/doc/config/haproxy.cfg
+++ b/doc/config/haproxy.cfg
@@ -6,28 +6,34 @@ defaults
     log global
     option httplog
     timeout client 1m
-	  timeout server 1m
-	  timeout connect 10s
-	  timeout http-keep-alive 2m
-	  timeout queue 15s
-	  timeout tunnel 4h  # for websocket
+	timeout server 1m
+	timeout connect 10s
+	timeout http-keep-alive 2m
+	timeout queue 15s
+	timeout tunnel 4h  # for websocket
 
 frontend test
     mode http
     bind *:80
+    
     unique-id-format %[uuid()]
     unique-id-header X-Unique-ID
-    log-format "%ci:%cp\ [%t]\ %ft\ %b/%s\ %Th/%Ti/%TR/%Tq/%Tw/%Tc/%Tr/%Tt\ %ST\ %B\ %CC\ %CS\ %tsc\ %ac/%fc/%bc/%sc/%rc\ %sq/%bq\ %hr\ %hs\ %{+Q}r\ %ID\ spoa-error:\ %[var(txn.coraza.error)]\ waf-hit:\ %[var(txn.coraza.fail)]"
+    filter spoe engine coraza config /etc/haproxy/coraza.cfg
+    
+    # Currently haproxy cannot use variables to set the code or deny_status, so this needs to be manually configured here
+    http-request redirect code 302 location %[var(txn.coraza.data)] if { var(txn.coraza.action) -m str redirect }
+    http-response redirect code 302 location %[var(txn.coraza.data)] if { var(txn.coraza.action) -m str redirect }
 
-    filter spoe engine coraza config coraza.cfg
+    http-request deny deny_status 403 hdr waf-block "request"  if { var(txn.coraza.action) -m str deny }
+    http-response deny deny_status 403 hdr waf-block "response" if { var(txn.coraza.action) -m str deny }
 
-    # Deny for Coraza WAF hits
-    http-request deny if { var(txn.coraza.fail) -m int eq 1 }
-    http-response deny if { var(txn.coraza.fail) -m int eq 1 }
+    http-request silent-drop if { var(txn.coraza.action) -m str drop }
+    http-response silent-drop if { var(txn.coraza.action) -m str drop }
 
     # Deny in case of an error, when processing with the Coraza SPOA
     http-request deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }
     http-response deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }
+
     use_backend test_backend
 
 backend test_backend
@@ -36,4 +42,6 @@ backend test_backend
 
 backend coraza-spoa
     mode tcp
-    server s1 127.0.0.1:9000
+    balance roundrobin
+    timeout connect 5s # greater than hello timeout
+    timeout server 3m  # greater than idle timeout


### PR DESCRIPTION
- Add an updated haproxy configuration example, and remove usage of `txn.coraza.fail`
- Update sample timeouts based upon comments from https://github.com/haproxy/haproxy/blob/master/doc/SPOE.txt#L604
- Disable the transaction cache by default, until we know its running stable