### PR TITLE
Fixed IPs to string convertation

### DIFF
--- a/internal/spoa.go
+++ b/internal/spoa.go
@@ -318,7 +318,7 @@ func (s *SPOA) processRequest(spoeMsg *spoe.Message) ([]spoe.Action, error) {
 		return s.processInterruption(it, hit), nil
 	}
 
-	tx.ProcessConnection(string(req.srcIp), req.srcPort, string(req.dstIp), req.dstPort)
+	tx.ProcessConnection(req.srcIp.String(), req.srcPort, req.dstIp.String(), req.dstPort)
 	tx.ProcessURI(req.path+"?"+req.query, req.method, "HTTP/"+req.version)
 
 	it = tx.ProcessRequestHeaders()


### PR DESCRIPTION
Closes #79.

```
coraza-spoa-coraza-1   | {"level":"error","ts":1689808068.161278,"msg":"[client \"172.18.0.1\"] Coraza: Access denied (phase 2). Inbound Anomaly Score Exceeded (Total Score: 10) [file \"/etc/coraza-spoa/rules/REQUEST-949-BLOCKING-EVALUATION.conf\"] [line \"9504\"] [id \"949110\"] [rev \"\"] [msg \"Inbound Anomaly Score Exceeded (Total Score: 10)\"] [data \"\"] [severity \"emergency\"] [ver \"OWASP_CRS/4.0.0-rc1\"] [maturity \"0\"] [accuracy \"0\"] [tag \"anomaly-evaluation\"] [hostname \"172.18.0.4\"] [uri \"/?x=/etc/passwd\"] [unique_id \"35c2afb4-14ea-4522-8273-724412d9d3ad\"]\n"}
```