### PR TITLE
Make build image verbose

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -10,6 +10,15 @@ services:
       target: coreruleset
     volumes:
       - ./docker/e2e/e2e-rules.conf:/etc/coraza-spoa/rules/000-e2e-rules.conf
+      - cor:/var/log/coraza-spoa
+    ports:
+      - 9000:9000
+    command:
+      [
+        "sh",
+        "-c",
+        "/usr/bin/coraza-spoa --config /etc/coraza-spoa/config.yaml 2>&1 | tee /var/log/coraza-spoa/coraza.log"
+      ]
   haproxy:
     depends_on:
       - coraza
@@ -19,12 +28,9 @@ services:
       [
         "sh",
         "-c",
-        "haproxy -f /usr/local/etc/haproxy/haproxy.cfg | tee /var/lib/haproxy/hap.log"
+        "haproxy -d -f /usr/local/etc/haproxy/haproxy.cfg 2>&1 | tee /var/lib/haproxy/hap.log"
       ]
-    ports: [ "4000:80" ]
-    links:
-      - "coraza:coraza"
-      - "httpbin:httpbin"
+    ports: [ "4000:4000" ]
     volumes:
       - type: bind
         source: ./docker/haproxy
@@ -34,13 +40,12 @@ services:
     depends_on:
       - haproxy
       - coraza
-    links:
-      - "haproxy:haproxy"
-      - "httpbin:httpbin"
     build:
       context: docker/e2e
       dockerfile: ./Dockerfile.curl
     volumes:
       - hap:/haproxy
+      - cor:/coraza
 volumes:
   hap:
+  cor:

--- a/docker/e2e/Dockerfile.curl
+++ b/docker/e2e/Dockerfile.curl
@@ -10,7 +10,7 @@ RUN apk add --no-cache bash
 
 COPY ./e2e.sh /workspace/e2e.sh
 
-ENV HAPROXY_HOST=haproxy:80
+ENV HAPROXY_HOST=haproxy:4000
 ENV HTTPBIN_HOST=httpbin:8080
 
 CMD ["bash", "/workspace/e2e.sh"]

--- a/docker/e2e/e2e.sh
+++ b/docker/e2e/e2e.sh
@@ -8,6 +8,7 @@
 HAPROXY_HOST=${HAPROXY_HOST:-"localhost:4000"}
 HTTPBIN_HOST=${HTTPBIN_HOST:-"localhost:8080"}
 HAPROXY_LOGS='/haproxy/hap.log'
+CORAZA_LOGS='/coraza/coraza.log'
 CURL_MAX_TIME=${CURL_MAX_TIME:-"2"}
 
 [[ "${DEBUG}" == "true" ]] && set -x
@@ -25,6 +26,17 @@ trueNegativeBodyPayload="This is a payload"
 truePositiveBodyPayload="maliciouspayload"
 trueNegativeBodyPayloadForResponseBody="Hello world"
 truePositiveBodyPayloadForResponseBody="responsebodycode"
+
+
+# print_logs prints haproxy and coraza logs
+function print_logs() {
+    echo ' ---------------------- haproxy ---------------------'
+    cat "${HAPROXY_LOGS}"
+    echo ' ---------------------- coraza ---------------------'
+    cat "${CORAZA_LOGS}"
+}
+trap print_logs EXIT
+
 
 # wait_for_service waits until the given URL returns a 200 status code.
 # $1: The URL to send requests to.

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -23,6 +23,7 @@ frontend stats
 frontend test_frontend
     mode http
     bind *:80
+    bind *:4000
     bind *:443 ssl crt /usr/local/etc/haproxy/example.com.pem alpn h2,http/1.1
     unique-id-format %[uuid()]
     unique-id-header X-Unique-ID


### PR DESCRIPTION
Debugging the current build failure was completely impossible without some debug output

- adding logs from coraza and haproxy to the output
- tidying the docker compose file
- using high ports only as port 80 seems to make issues (!?)

This includes #98 as its just necessary.