### PR TITLE
Fix image build

### DIFF
--- a/doc/config/coraza.cfg
+++ b/doc/config/coraza.cfg
@@ -22,3 +22,5 @@ spoe-message coraza-req
 spoe-message coraza-res
     args app=str(sample_app) id=unique-id version=res.ver status=status headers=res.hdrs body=res.body
     event on-http-response
+
+

--- a/docker/haproxy/coraza.cfg
+++ b/docker/haproxy/coraza.cfg
@@ -22,3 +22,5 @@ spoe-message coraza-req
 spoe-message coraza-res
     args app=str(sample_app) id=unique-id version=res.ver status=status headers=res.hdrs body=res.body
     event on-http-response
+
+

--- a/docker/haproxy/coraza.cfg
+++ b/docker/haproxy/coraza.cfg
@@ -1,19 +1,24 @@
 # https://github.com/haproxy/haproxy/blob/master/doc/SPOE.txt
+# /etc/haproxy/coraza.cfg
 [coraza]
 spoe-agent coraza-agent
-    messages    coraza-req      coraza-res
+    # Process HTTP requests only (the responses are not evaluated)
+    messages    coraza-req
+    # Comment the previous line and add coraza-res, to process responses also.
+    # NOTE: there are still some memory & caching issues, so use this with care
+    #messages   coraza-req     coraza-res
     option      var-prefix      coraza
     option      set-on-error    error
-    timeout     hello           100ms
+    timeout     hello           2s
     timeout     idle            2m
     timeout     processing      500ms
     use-backend coraza-spoa
     log         global
 
 spoe-message coraza-req
-    args app=fe_name id=unique-id src-ip=src src-port=src_port dst-ip=dst dst-port=dst_port method=method path=path query=query version=req.ver headers=req.hdrs body=req.body
+    args app=str(sample_app) id=unique-id src-ip=src src-port=src_port dst-ip=dst dst-port=dst_port method=method path=path query=query version=req.ver headers=req.hdrs body=req.body
     event on-frontend-http-request
 
 spoe-message coraza-res
-    args app=fe_name id=unique-id version=res.ver status=status headers=res.hdrs body=res.body
+    args app=str(sample_app) id=unique-id version=res.ver status=status headers=res.hdrs body=res.body
     event on-http-response


### PR DESCRIPTION
Building the docker image failed on two issues:

- since 8f29491 coraza.cfg didn't fit the coraza version anymore. It was only updated in the doc folder
- haproxy starting with 2.3 requires a LF at the end of config files, that was also missing.