### PR TITLE
test: use go version from go.mod

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,8 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-      - run: go run mage.go lint
+          go-version-file: 'go.mod'
+
+      - name: Lint
+        run: go run mage.go lint

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,9 +12,13 @@ jobs:
   build:
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        arch: [ amd64, arm64 ]
     runs-on: ubuntu-24.04
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
       - name: Print Go version and environment
         id: vars

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -15,6 +15,8 @@ jobs:
         arch: [ amd64, arm64 ]
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -41,8 +43,6 @@ jobs:
           else
             echo "PACKAGE_VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
           fi
-
-      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
 
       - name: setup environment
         run: |


### PR DESCRIPTION
Also use the correct go version for building the package, and not the version from the system (Ubuntu 24.04)
Fixes #146