### PR TITLE
test: [OLD] Add HAProxy version-matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,11 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        haproxy-version: [ 3.0, 2.8 ]  # 3.1
+
+    runs-on: ubuntu-latest
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -18,7 +23,7 @@ jobs:
       - name: setup environment
         run: |
           sudo apt-get install -y software-properties-common
-          sudo add-apt-repository -y ppa:vbernat/haproxy-2.8
+          sudo add-apt-repository -y ppa:vbernat/haproxy-${{ matrix.haproxy-version }}
           sudo apt-get update
           sudo apt-get install -y haproxy
           haproxy -vv

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        haproxy-version: [ '3.0', '2.8' ]  # 3.1, 3.2
-        os:
-          - 'ubuntu-latest'  # fallback - we override it
         include:
           - haproxy-version: '2.8'
             os: 'ubuntu-22.04'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,3 +1,4 @@
+---
 name: Test
 
 on:
@@ -7,11 +8,18 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
-        haproxy-version: [ 3.0, 2.8 ]  # 3.1
+        haproxy-version: [ '3.0', '2.8' ]  # 3.1, 3.2
+        os:
+          - 'ubuntu-latest'  # fallback - we override it
+        include:
+          - haproxy-version: '2.8'
+            os: 'ubuntu-22.04'
+          - haproxy-version: '3.0'
+            os: 'ubuntu-24.04'
 
-    runs-on: ubuntu-latest
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 


### PR DESCRIPTION
This PR adds multi-version support to the test workflow as mentioned in this issue: https://github.com/corazawaf/coraza-spoa/issues/160

Version 3.1 is not included as it seems to have an issue with response-check handling: https://github.com/corazawaf/coraza-spoa/issues/162