### PR TITLE
Log the end of successful config reload event

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,6 +137,7 @@ outer:
 				continue
 			}
 			cfg = newCfg
+			globalLogger.Info().Msg("Configuration successfully reloaded")
 		}
 	}
 


### PR DESCRIPTION
It would be nice to see how long the config reload takes in deployments with many applications (especially without memoize). 