### PR TITLE
Log successful reload on config update

### DIFF
--- a/config.go
+++ b/config.go
@@ -124,6 +124,7 @@ func (c *config) watchConfig(a *internal.Agent) error {
 					continue
 				}
 				c = newCfg
+				globalLogger.Info().Msg("Configuration successfully reloaded")
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {

--- a/config.go
+++ b/config.go
@@ -82,6 +82,7 @@ func (c *config) reloadConfig(a *internal.Agent) (*config, error) {
 	}
 
 	a.ReplaceApplications(apps)
+	globalLogger.Info().Msg("Configuration successfully reloaded")
 	return newCfg, nil
 }
 
@@ -124,7 +125,6 @@ func (c *config) watchConfig(a *internal.Agent) error {
 					continue
 				}
 				c = newCfg
-				globalLogger.Info().Msg("Configuration successfully reloaded")
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {

--- a/main.go
+++ b/main.go
@@ -137,7 +137,6 @@ outer:
 				continue
 			}
 			cfg = newCfg
-			globalLogger.Info().Msg("Configuration successfully reloaded")
 		}
 	}
 


### PR DESCRIPTION
I realized that in https://github.com/corazawaf/coraza-spoa/pull/208 I forgot to add logging to config watcher as well.

Alternatively, I could move this log message to `reloadConfig()` to avoid repeating code.