### PR TITLE
docs: fix wrong variable name in haproxy.cfg

### DIFF
--- a/example/haproxy/haproxy.cfg
+++ b/example/haproxy/haproxy.cfg
@@ -12,7 +12,7 @@ defaults
 frontend default
     mode http
     bind *:80
-    log-format "%ci:%cp\ [%t]\ %ft\ %b/%s\ %Th/%Ti/%TR/%Tq/%Tw/%Tc/%Tr/%Tt\ %ST\ %B\ %CC\ %CS\ %tsc\ %ac/%fc/%bc/%sc/%rc\ %sq/%bq\ %hr\ %hs\ %{+Q}r\ %[var(txn.coraza.id)]\ spoa-error:\ %[var(txn.coraza.error)]\ waf-hit:\ %[var(txn.coraza.fail)]"
+    log-format "%ci:%cp\ [%t]\ %ft\ %b/%s\ %Th/%Ti/%TR/%Tq/%Tw/%Tc/%Tr/%Tt\ %ST\ %B\ %CC\ %CS\ %tsc\ %ac/%fc/%bc/%sc/%rc\ %sq/%bq\ %hr\ %hs\ %{+Q}r\ %[var(txn.coraza.id)]\ spoa-error:\ %[var(txn.coraza.error)]\ waf-hit:\ %[var(txn.coraza.status)]"
 
     # Set coraza app in HAProxy config to allow customized configs per host.
     # You can also just leave this as is or even replace the use of a variable


### PR DESCRIPTION
Thanks @jcrood for pointing this one out.

Closes #71