### PR TITLE
Add helm chart

### DIFF
--- a/chart/coraza-spoa/.helmignore
+++ b/chart/coraza-spoa/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/coraza-spoa/Chart.yaml
+++ b/chart/coraza-spoa/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: coraza-spoa
+description: A Helm chart for Kubernetes to deploy Coraza SPOA WAF
+home: https://github.com/corazawaf/coraza-spoa
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - waf
+  - coraza
+  - spoa
+  - haproxy

--- a/chart/coraza-spoa/templates/_helpers.tpl
+++ b/chart/coraza-spoa/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "coraza-spoa.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "coraza-spoa.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "coraza-spoa.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "coraza-spoa.labels" -}}
+helm.sh/chart: {{ include "coraza-spoa.chart" . }}
+{{ include "coraza-spoa.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "coraza-spoa.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "coraza-spoa.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/coraza-spoa/templates/configmap.yaml
+++ b/chart/coraza-spoa/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "coraza-spoa.fullname" . }}
+  labels:
+    {{- include "coraza-spoa.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}
+  pre_rules.conf: |
+    {{- .Values.rules.pre | nindent 4 }}
+  post_rules.conf: |
+    {{- .Values.rules.post | nindent 4 }}

--- a/chart/coraza-spoa/templates/deployment.yaml
+++ b/chart/coraza-spoa/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "coraza-spoa.fullname" . }}
+  labels:
+    {{- include "coraza-spoa.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "coraza-spoa.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "coraza-spoa.labels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /coraza-spoa
+            - --config
+            - /etc/coraza/config.yaml
+            - --autoreload
+            {{- if .Values.metrics.enabled }}
+            - --metrics-addr=:{{ .Values.metrics.port }}
+            {{- end }}
+          ports:
+            - name: spoa
+              containerPort: {{ regexSplit ":" .Values.config.bind -1 | last }}
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/coraza
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "coraza-spoa.fullname" . }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/coraza-spoa/templates/hpa.yaml
+++ b/chart/coraza-spoa/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "coraza-spoa.fullname" . }}
+  labels:
+    {{- include "coraza-spoa.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "coraza-spoa.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/chart/coraza-spoa/templates/service.yaml
+++ b/chart/coraza-spoa/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "coraza-spoa.fullname" . }}
+  labels:
+    {{- include "coraza-spoa.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ regexSplit ":" .Values.config.bind -1 | last }}
+      protocol: TCP
+      name: spoa
+    {{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.port }}
+      protocol: TCP
+      name: metrics
+    {{- end }}
+  selector:
+    {{- include "coraza-spoa.selectorLabels" . | nindent 4 }}

--- a/chart/coraza-spoa/templates/servicemonitor.yaml
+++ b/chart/coraza-spoa/templates/servicemonitor.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "coraza-spoa.fullname" . }}
+  labels:
+    {{- include "coraza-spoa.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "coraza-spoa.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - path: /metrics
+      port: metrics
+{{- end }}

--- a/chart/coraza-spoa/values.yaml
+++ b/chart/coraza-spoa/values.yaml
@@ -1,0 +1,65 @@
+# Default values for coraza-spoa.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: ghcr.io/corazawaf/coraza-spoa@sha256
+  pullPolicy: IfNotPresent
+  tag: "b048f19913493b870e1ccc3f1eac62929208ad628a5faa3cf0e6e1dd0079a609"
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+resources: {}
+
+volumes: []
+volumeMounts: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+metrics:
+  enabled: true
+  port: 9100
+  serviceMonitor:
+    enabled: true
+
+# -- Coraza SPOA configuration: https://github.com/corazawaf/coraza-spoa/blob/main/example/coraza-spoa.yaml
+config:
+  bind: 0.0.0.0:9000
+  log_file: /dev/stdout
+  log_format: json
+  log_level: info
+  default_application: default-app
+  applications:
+    - name: default-app
+      log_file: /dev/stdout
+      log_format: json
+      log_level: error
+      response_check: false
+      transaction_ttl_ms: 60000
+      directives: |
+        Include @coraza.conf-recommended
+        Include @crs-setup.conf.example
+        Include /etc/coraza/pre_rules.conf
+        Include @owasp_crs/*.conf
+        Include /etc/coraza/post_rules.conf
+
+# -- Custom rules that will be mounted as separate files.
+rules:
+  # -- These rules will be mounted at `/etc/coraza/pre_rules.conf`
+  pre: |-
+    # SecRule REQUEST_HEADERS:Host "@endsWith DOMAIN" "id:1,phase:1,pass,nolog,t:none,ctl:ruleRemoveById=ID"
+  # -- These rules will be mounted at `/etc/coraza/post_rules.conf`
+  post: |-
+    SecRuleEngine On


### PR DESCRIPTION
Introducing an official helm chart will be yet another step towards productionizing this project for k8s crowd.

If that is something you could agree to, then in the following PRs we will configure testing and release workflows:

- https://github.com/helm/chart-testing-action
- https://github.com/helm/chart-releaser-action

---

But perhaps before merging this, it makes sense to revisit CI and go for tagged versioned image releases only. Cause currently, we are building with each merge and helm image tag will be always one step behind. 

Wdyt?