### PR TITLE
ci: fix container image build workflow

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -5,9 +5,17 @@ on:
       - main
     tags:
       - "*"
-    paths-ignore:
-      - "**/*.md"
-      - "LICENSE"
+    paths:
+      # build a semver tagged image after release-please pr merge
+      - CHANGELOG.md
+      # build a snapshot tagged image after any app change
+      - main.go
+      - config.go
+      - go.sum
+      - go.mod
+      - internal/*
+      - example/Dockerfile
+      - example/coraza-spoa.yaml
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
The release-please action creates tagged PRs that contain only changes to CHANGELOG.md
So, the image build action will never run after we merge a release-please PR.
This PR tries to rectify this issue and additionally avoid unnecessary image builds by limiting the paths.