### PR TITLE
feat: print matched error logs as json if requested

### DIFF
--- a/config.go
+++ b/config.go
@@ -163,6 +163,7 @@ func (c config) newApplications() (map[string]*internal.Application, error) {
 			Logger:         logger,
 			Directives:     a.Directives,
 			ResponseCheck:  a.ResponseCheck,
+			LogFormat:      a.Log.Format,
 			TransactionTTL: time.Duration(a.TransactionTTLMS) * time.Millisecond,
 		}
 


### PR DESCRIPTION
Previously the json handler would only wrap the message in a json object. This now replaces that message with an embedded object that contains all the information.

Thanks to @superstes for implementing this in his fork