### PR TITLE
fix: Systemd-Service auto-restart

### DIFF
--- a/contrib/coraza-spoa.service
+++ b/contrib/coraza-spoa.service
@@ -6,6 +6,7 @@ Documentation=https://www.coraza.io
 ExecStart=/usr/bin/coraza-spoa -config=/etc/coraza-spoa/config.yaml
 WorkingDirectory=/
 Restart=always
+RestartSec=1
 Type=exec
 User=coraza-spoa
 Group=coraza-spoa


### PR DESCRIPTION
Greetings!

The auto-restart in the current Systemd-Service may fail as no `RestartSec` is set.

It produces this well-known error:

```
Nov 16 00:00:03 lb01 systemd[1]: coraza-spoa.service: Start request repeated too quickly.
Nov 16 00:00:03 lb01 systemd[1]: coraza-spoa.service: Failed with result 'start-limit-hit'.
Nov 16 00:00:03 lb01 systemd[1]: Failed to start coraza-spoa.service - Coraza WAF SPOA Daemon.
```

See: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#RestartSec=