### PR TITLE
ci(image): support multi-platform builds by adding arm64 to Docker build

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -70,7 +70,7 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           file: example/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-main.outputs.tags }}


### PR DESCRIPTION
I noticed the latest image `0.5.1` lacks support for `linux/arm64` architecture. We should also distribute the container image for this architecture just like the binary.