### PR TITLE
fix: correlate response for interrupted requests in detect-only mode

### DIFF
--- a/internal/application.go
+++ b/internal/application.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"runtime/debug"
@@ -60,6 +61,7 @@ type applicationRequest struct {
 	Headers       []byte
 	Body          []byte
 	ExportRuleIDs bool
+	DetectOnly    bool
 }
 
 func (a *Application) HandleRequest(ctx context.Context, writer *encoding.ActionWriter, message *encoding.Message) (err error) {
@@ -133,6 +135,8 @@ func (a *Application) HandleRequest(ctx context.Context, writer *encoding.Action
 			req.ID = string(k.ValueBytes())
 		case "exportRuleIDs":
 			req.ExportRuleIDs = k.ValueBool()
+		case "detect-only":
+			req.DetectOnly = k.ValueBool()
 		default:
 			a.Logger.Debug().Str("name", name).Msg("unknown kv entry")
 		}
@@ -151,9 +155,28 @@ func (a *Application) HandleRequest(ctx context.Context, writer *encoding.Action
 
 	tx := a.waf.NewTransactionWithID(req.ID)
 	defer func() {
-		if err == nil && a.ResponseCheck {
-			a.cache.SetWithExpiration(tx.ID(), &transaction{tx: tx}, a.TransactionTTL)
-			return
+		// Cache the transaction for response-phase correlation when response
+		// checking is enabled and either:
+		//   - the request passed cleanly (err == nil), or
+		//   - we are in detect-only mode and the request raised an interruption.
+		//
+		// In detect-only mode HAProxy does NOT enforce the interruption: it
+		// forwards the request to the origin anyway, so a response will still
+		// arrive over coraza-res and must be correlated to this transaction.
+		// The transaction's lifecycle therefore extends to the response phase,
+		// exactly like a non-interrupted request. Without caching it here,
+		// HandleResponse would fail to find it and the response (and its
+		// logging / inspection) would be lost.
+		//
+		// If the response never arrives, the TTL eviction callback closes and
+		// logs the transaction, the same safety net every cached transaction
+		// already relies on.
+		if a.ResponseCheck {
+			var interruption ErrInterrupted
+			if err == nil || (req.DetectOnly && errors.As(err, &interruption)) {
+				a.cache.SetWithExpiration(tx.ID(), &transaction{tx: tx}, a.TransactionTTL)
+				return
+			}
 		}
 
 		tx.ProcessLogging()

--- a/internal/e2e_test.go
+++ b/internal/e2e_test.go
@@ -94,6 +94,35 @@ SecRuleEngine On
 		})
 	})
 
+	t.Run("request detect-only forwards and correlates response", func(t *testing.T) {
+		// Full detect-only: HAProxy does not enforce the verdict, so a request
+		// the WAF would deny is forwarded to the origin and its response
+		// returned. The interrupted request transaction must still be cached so
+		// the response can be correlated; otherwise HandleResponse fails with
+		// "transaction not found" and the request is denied with a 504.
+		config, _, _ := runCorazaRequestDetectOnly(t, defaultCorazaConfig)
+
+		req, _ := http.NewRequest("GET", "http://127.0.0.1:"+config.FrontendPort+"/anything?arg=<script>alert(0)</script>", http.NoBody)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		// Forwarded to the origin (httpbin /anything echoes with 200), proving
+		// the request was not blocked and the response was correlated/logged
+		// rather than lost (which would yield a 504).
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status code to be \"%d\", but got \"%d\"", http.StatusOK, resp.StatusCode)
+		}
+
+		// The WAF still detected the malicious request (request-phase metrics
+		// are exported even when the verdict is not enforced).
+		if ruleIDs := resp.Header.Get("X-Rule-IDs"); ruleIDs == "" {
+			t.Errorf("expected rule_ids to be not empty (request should still be detected)")
+		}
+	})
+
 	t.Run("default config", func(t *testing.T) {
 		config, _, _ := runCoraza(t, defaultCorazaConfig)
 
@@ -229,6 +258,67 @@ spoe-message coraza-req
 
 spoe-message coraza-res
     args app=str(default) id=var(txn.e2e.id) version=res.ver status=status headers=res.hdrs body=res.body exportRuleIDs=bool(true)
+    event on-http-response
+`,
+		BackendConfig: fmt.Sprintf(`
+mode http
+server httpbin %s
+`, backendAddr),
+	}
+
+	frontendSocket := cfg.Run(tb)
+
+	return cfg, binURL, frontendSocket
+}
+
+// runCorazaRequestDetectOnly models full detect-only mode: HAProxy does NOT
+// enforce the WAF verdict, so requests that the WAF would deny are still
+// forwarded to the origin and their responses delivered. Both coraza-req and
+// coraza-res carry detect-only=bool(true). The only deny left is the 504 on a
+// SPOA processing error, so a failed request/response correlation (e.g. a
+// "transaction not found" because an interrupted request was not cached)
+// surfaces as a 504 instead of the expected 200.
+func runCorazaRequestDetectOnly(tb testing.TB, directives string) (testutil.HAProxyConfig, string, string) {
+	a, binURL, backendAddr := setupCorazaAgent(tb, directives)
+
+	// create the listener synchronously to prevent a race
+	l := testutil.TCPListener(tb)
+	// ignore errors as the listener will be closed by t.Cleanup
+	go a.Serve(l)
+
+	cfg := testutil.HAProxyConfig{
+		EngineAddr:   l.Addr().String(),
+		FrontendPort: fmt.Sprintf("%d", testutil.TCPPort(tb)),
+		CustomFrontendConfig: `
+    http-after-response set-header X-Anomaly-Score "%[var(txn.e2e.anomaly_score)]"
+    http-after-response set-header X-Rules-Hit "%[var(txn.e2e.rules_hit)]"
+    http-after-response set-header X-Rule-IDs "%[var(txn.e2e.rule_ids)]"
+
+    # No is_deny enforcement: the WAF verdict is detected and logged but never
+    # blocks, so every request reaches the origin and every response is returned.
+
+    # Deny only when the SPOA itself errors, so a lost transaction surfaces.
+    http-request deny deny_status 504 if { var(txn.e2e.error) -m int gt 0 }
+    http-response deny deny_status 504 if { var(txn.e2e.error) -m int gt 0 }
+`,
+		EngineConfig: `
+[e2e]
+spoe-agent e2e
+    messages    coraza-req     coraza-res
+    option      var-prefix      e2e
+    option      set-on-error    error
+    timeout     hello           2s
+    timeout     idle            2m
+    timeout     processing      500ms
+    use-backend e2e-spoa
+    log         global
+
+spoe-message coraza-req
+    args app=str(default) src-ip=src src-port=src_port dst-ip=dst dst-port=dst_port method=method path=path query=query version=req.ver headers=req.hdrs body=req.body exportRuleIDs=bool(true) detect-only=bool(true)
+    event on-frontend-http-request
+
+spoe-message coraza-res
+    args app=str(default) id=var(txn.e2e.id) version=res.ver status=status headers=res.hdrs body=res.body exportRuleIDs=bool(true) detect-only=bool(true)
     event on-http-response
 `,
 		BackendConfig: fmt.Sprintf(`


### PR DESCRIPTION
In detect-only mode HAProxy does not enforce the WAF verdict: a request that raised an interruption is still forwarded to the origin, so a response arrives over coraza-res and must be correlated to the transaction. HandleRequest previously cached the transaction only when the request passed cleanly (err == nil), so an interrupted-but-forwarded request was logged and closed immediately. The later coraza-res then failed with "transaction not found", losing the response (headers/body) and its logging/inspection entirely.

Add a detect-only arg to coraza-req (mirroring coraza-res) and cache the transaction when detect-only is set even if the request was interrupted, so the response phase can complete. If the response never arrives, the existing TTL eviction callback closes and logs the transaction, the same safety net every cached transaction already relies on.

In enforcing (on) mode the request is genuinely blocked at HAProxy with no origin response, so the immediate log-and-close path is unchanged.

Adds an e2e test covering full detect-only mode: an interrupted request is forwarded to the origin and its response correlated rather than lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved **detect-only** mode: security verdicts are not enforced, but detection and metrics are still recorded.
  * Verify-and-forward behavior now covers both **request and response** flows, ensuring traffic reaches the origin while detection headers/IDs remain present.
  * Only SPO processing failures (e.g., correlation issues) can surface as a **504**, rather than blocking requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->