### PR TITLE
fix: surface -validate errors on stderr and name the failing application

### DIFF
--- a/config.go
+++ b/config.go
@@ -153,10 +153,10 @@ func (c *config) watchConfig(a *internal.Agent) error {
 func (c config) newApplications() (map[string]*internal.Application, error) {
 	allApps := make(map[string]*internal.Application)
 
-	for name, a := range c.Applications {
+	for _, a := range c.Applications {
 		logger, err := a.Log.newLogger()
 		if err != nil {
-			return nil, fmt.Errorf("creating logger for application %q: %v", name, err)
+			return nil, fmt.Errorf("creating logger for application %q: %v", a.Name, err)
 		}
 
 		appConfig := internal.AppConfig{
@@ -169,7 +169,7 @@ func (c config) newApplications() (map[string]*internal.Application, error) {
 
 		application, err := appConfig.NewApplication()
 		if err != nil {
-			return nil, fmt.Errorf("initializing application %q: %v", name, err)
+			return nil, fmt.Errorf("initializing application %q: %v", a.Name, err)
 		}
 
 		allApps[a.Name] = application

--- a/main.go
+++ b/main.go
@@ -80,7 +80,13 @@ func main() {
 	if err != nil {
 		globalLogger.Fatal().Err(err).Msg("Failed creating global logger")
 	}
-	globalLogger = logger
+	// In validate mode keep logging on stderr so parse/compile errors reach
+	// the caller instead of disappearing into the configured log file. The
+	// configured logger is still created above so bad log settings fail
+	// validation too.
+	if !validateConfig {
+		globalLogger = logger
+	}
 
 	apps, err := cfg.newApplications()
 	if err != nil {


### PR DESCRIPTION
In validate mode the global logger no longer switches to the configured log_file, so parse/compile errors reach the caller's stderr instead of disappearing into the log file (the configured logger is still created, so bad log settings fail validation too).

newApplications() ranged over the applications slice using the index as the name in error messages, rendering as '\x00' for the first app; use the application's actual name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation mode (-validate flag) now correctly outputs parse, compile, and validation errors to stderr instead of using the configured logger. This ensures proper error visibility during validation workflows. Standard operation continues using your configured logger.

* **Refactor**
  * Application initialization error message handling improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->