### PR TITLE
Enhance statistics tracking and reporting

### DIFF
--- a/internal/agent.go
+++ b/internal/agent.go
@@ -61,6 +61,9 @@ func (a *Agent) DrainDetectOnly() {
 func (a *Agent) HandleSPOE(ctx context.Context, writer *encoding.ActionWriter, message *encoding.Message) {
 	timer := prometheus.NewTimer(handleSPOEDuration)
 	defer timer.ObserveDuration()
+	
+	// Increment request counter
+	handleSPOECount.Inc()
 
 	const (
 		messageCorazaRequest  = "coraza-req"

--- a/internal/application.go
+++ b/internal/application.go
@@ -516,15 +516,14 @@ func (a *Application) logCallback(mr types.MatchedRule) {
 	// Record metrics for matched rules
 	
 	// Increment counter by severity if severity is valid
-	if severity := rule.Severity(); severity.String() != "" {
-		severityStr := severity.String()
-		if severityStr != "" {
-			handleResponsesBySeverity.WithLabelValues(severityStr).Inc()
-		} else {
-			a.Logger.Debug().Int("severity", severity.Int()).Msg("invalid severity in logCallback")
-		}
+	severity := rule.Severity()
+	severityStr := severity.String()
+	if severityStr != "" {
+		handleResponsesBySeverity.WithLabelValues(severityStr).Inc()
+	} else {
+		a.Logger.Debug().Int("severity", severity.Int()).Msg("invalid severity in logCallback")
 	}
-	
+		
 	// Increment counter by rule if ID is valid (> 0)
 	if ruleID := rule.ID(); ruleID > 0 {
 		ruleIDStr := strconv.Itoa(ruleID)

--- a/internal/application.go
+++ b/internal/application.go
@@ -516,7 +516,7 @@ func (a *Application) logCallback(mr types.MatchedRule) {
 	// Record metrics for matched rules
 	
 	// Increment counter by severity if severity is valid
-	if severity := rule.Severity(); severity != 0 {
+	if severity := rule.Severity(); severity.String() != "" {
 		severityStr := severity.String()
 		if severityStr != "" {
 			handleResponsesBySeverity.WithLabelValues(severityStr).Inc()

--- a/internal/application.go
+++ b/internal/application.go
@@ -501,6 +501,48 @@ func phaseToString(phase types.RulePhase) string {
 }
 
 func (a *Application) logCallback(mr types.MatchedRule) {
+	// Check that mr and rule are not nil
+	if mr == nil {
+		a.Logger.Warn().Msg("matched rule is nil in logCallback")
+		return
+	}
+	
+	rule := mr.Rule()
+	if rule == nil {
+		a.Logger.Warn().Msg("rule is nil in logCallback")
+		return
+	}
+	
+	// Record metrics for matched rules
+	
+	// Increment counter by severity if severity is valid
+	if severity := rule.Severity(); severity != 0 {
+		severityStr := severity.String()
+		if severityStr != "" {
+			handleResponsesBySeverity.WithLabelValues(severityStr).Inc()
+		} else {
+			a.Logger.Debug().Int("severity", severity.Int()).Msg("invalid severity in logCallback")
+		}
+	}
+	
+	// Increment counter by rule if ID is valid (> 0)
+	if ruleID := rule.ID(); ruleID > 0 {
+		ruleIDStr := strconv.Itoa(ruleID)
+		handleResponsesByRule.WithLabelValues(ruleIDStr).Inc()
+	} else {
+		a.Logger.Debug().Int("rule_id", ruleID).Msg("invalid rule ID in logCallback")
+	}
+	
+	// Update version metric if available and not empty
+	if version := rule.Version(); version != "" {
+		// Check that version contains only valid characters for Prometheus
+		if len(version) > 0 && len(version) < 256 {
+			handleVersion.WithLabelValues(version).Set(1)
+		} else {
+			a.Logger.Debug().Str("version", version).Msg("invalid version format in logCallback")
+		}
+	}
+
 	var l *zerolog.Event
 
 	switch mr.Rule().Severity() {

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -13,4 +13,39 @@ var (
 			Buckets: prometheus.DefBuckets,
 		},
 	)
+
+	// Counter for the number of SPOE requests processed
+	handleSPOECount = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "coraza_handle_spoe_count",
+			Help: "Total number of SPOE requests handled",
+		},
+	)
+
+	// Counter of responses by severity
+	handleResponsesBySeverity = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "coraza_handle_responses_severity",
+			Help: "Number of responses by severity",
+		},
+		[]string{"severity"},
+	)
+
+	// Counter of responses by rule
+	handleResponsesByRule = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "coraza_handle_responses_rules",
+			Help: "Number of responses by rule ID",
+		},
+		[]string{"rule_id"},
+	)
+
+	// Gauge for OWASP CRS version
+	handleVersion = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "coraza_handle_version",
+			Help: "OWASP CRS version information",
+		},
+		[]string{"version"},
+	)
 )


### PR DESCRIPTION
This pull request adds new Prometheus metrics to improve observability of the application's request handling and rule matching. It introduces counters and gauges to track SPOE requests, responses by severity and rule, and the CRS version. Additionally, it updates the logging callback to increment these metrics and adds validation for matched rules and rule data.

They are very useful to build a much more verbose Grafana dashboard and they do not complexify the source code.


**Metrics instrumentation:**

* Added `handleSPOECount` counter to track the total number of SPOE requests handled, incremented in `Agent.HandleSPOE`. 
* Added `handleResponsesBySeverity` and `handleResponsesByRule` counters to track the number of responses by severity and rule ID, respectively, and instrumented them in `Application.logCallback`. 
* Added `handleVersion` gauge to track the CRS version, set in `Application.logCallback` when a valid version is present. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for SPOE request volume and processing activity.
  * Added response metrics grouped by severity and rule ID.
  * Added an OWASP CRS version metric when a valid version is reported.
  * Expanded observability into response outcomes and deployed rule-set versions.
  * Request-volume metrics now reflect handled Coraza request messages, improving monitoring accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->