### PR TITLE
chore(deps): switch distroless image to static-debian13 using f2ea270 digest

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -11,7 +11,7 @@ RUN go vet -v ./...
 
 RUN CGO_ENABLED=0 go build -o /go/bin/coraza-spoa
 
-FROM gcr.io/distroless/static-debian11@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
+FROM gcr.io/distroless/static-debian13@sha256:f2ea2709ac8db56323cbd7d014277f32cb572d9ea124b0076f7aafe5980678fe
 
 LABEL org.opencontainers.image.authors="The OWASP Coraza contributors" \
       org.opencontainers.image.description="OWASP Coraza WAF (Haproxy SPOA)" \

--- a/ftw/Dockerfile.coraza_spoa
+++ b/ftw/Dockerfile.coraza_spoa
@@ -11,7 +11,7 @@ RUN go vet -v ./...
 
 RUN CGO_ENABLED=0 go build -o /go/bin/coraza-spoa
 
-FROM gcr.io/distroless/static-debian12@sha256:20bc6c0bc4d625a22a8fde3e55f6515709b32055ef8fb9cfbddaa06d1760f838
+FROM gcr.io/distroless/static-debian13@sha256:f2ea2709ac8db56323cbd7d014277f32cb572d9ea124b0076f7aafe5980678fe
 
 LABEL org.opencontainers.image.authors="The OWASP Coraza contributors" \
       org.opencontainers.image.description="OWASP Coraza WAF (Haproxy SPOA)" \


### PR DESCRIPTION
- `static-debian11` is already deprecated, and Debian 11 reaches EOL on August 31, 2026.
- Update both Dockerfiles to use `static-debian13`, ensuring consistency between them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime container images to newer pinned Distroless Debian versions.
  * Maintains minimal, secure runtime environments for example and Coraza deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->